### PR TITLE
Renamed 'bin' folder to 'binaries' (the name is expected by the tabni…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,9 +12,9 @@ triple="$(uname -m)-$platform"
 
 cd $(dirname $0)
 path=$version/$triple/TabNine
-if [ -f bin/$path ]; then
+if [ -f binaries/$path ]; then
     exit
 fi
 echo Downloading version $version
-curl https://update.tabnine.com/$path --create-dirs -o bin/$path
-chmod +x bin/$path
+curl https://update.tabnine.com/$path --create-dirs -o binaries/$path
+chmod +x binaries/$path

--- a/rplugin/python3/deoplete/sources/tabnine.py
+++ b/rplugin/python3/deoplete/sources/tabnine.py
@@ -78,7 +78,7 @@ class Source(Base):
         if self.proc is not None:
             self.proc.terminate()
             self.proc = None
-        binary_dir = os.path.join(self._install_dir, 'bin')
+        binary_dir = os.path.join(self._install_dir, 'binaries')
         path = get_tabnine_path(binary_dir)
         if path is None:
             self.print_error('no TabNine binary found')


### PR DESCRIPTION
Renamed 'bin' folder to 'binaries'. That exact folder name is expected by the tabnine executable and required for registration to work.

Fixes issue #2 