### PR TITLE
Windows support

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,35 @@
+[Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
+
+$web = New-Object Net.WebClient
+$versionUrl = "https://update.tabnine.com/version"
+
+$version = $web.DownloadString($versionUrl).replace("`n","")
+
+$arch_raw = Get-CimInstance Win32_OperatingSystem | Select-Object 'OSArchitecture' | Format-Table -HideTableHeaders | Out-String
+
+switch ( $arch_raw.Trim().Substring(0,2) ) {
+  "64" { $arch = "x86_64" }
+  "32" { $arch = "i686" }
+}
+$triple = ( $arch + "-pc-windows-gnu" )
+
+$path = "$PSScriptRoot\binaries\$version\$triple"
+
+$url = ( "https://update.tabnine.com/$version/$triple/TabNine.exe" )
+if (!(Test-Path -Path "$path\TabNine.exe"))  {
+  Write-Host "Downloading TabNine executable..."
+  New-Item -ItemType directory -Path $path
+
+  Try {
+  $web.DownloadFile(
+    $url,
+    $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath(
+      "$path\TabNine.exe"
+    )
+  )
+  Write-Host "Successful!"
+  }
+  Catch {
+    Write-Host $($_.Exception.ToString())
+  }
+}

--- a/rplugin/python3/deoplete/sources/tabnine.py
+++ b/rplugin/python3/deoplete/sources/tabnine.py
@@ -114,12 +114,25 @@ def get_tabnine_path(binary_dir):
     SYSTEM_MAPPING = {
         'Darwin': 'apple-darwin',
         'Linux': 'unknown-linux-gnu',
+        'Windows': 'pc-windows-gnu'
     }
     versions = os.listdir(binary_dir)
     versions.sort(key=parse_semver, reverse=True)
     for version in versions:
-        triple = '{}-{}'.format(platform.machine(),
+        triple = '{}-{}'.format(parse_architecture(platform.machine()),
                                 SYSTEM_MAPPING[platform.system()])
-        path = os.path.join(binary_dir, version, triple, 'TabNine')
+        path = os.path.join(binary_dir, version, triple, executable_name('TabNine'))
         if os.path.isfile(path):
             return path
+
+def parse_architecture(arch):
+    if arch == 'AMD64':
+        return 'x86_64'
+    else:
+        return arch
+
+def executable_name(name):
+    if platform.system() == 'Windows':
+        return name + '.exe'
+    else:
+        return name


### PR DESCRIPTION
Hey! 

This adds support for Windows (tested with Nvim 0.3.1 on Windows 10). It should be useable anywhere with PowerShell 3+ installed.  I don't have access to Linux of macOS machines, so if possible, it should be tested on those machines before a merge. Someone with a bit more python know-how than me might want to take a glance at the code as well, to make sure I haven't done anything awful.

To add (with Vim-Plug), exchange 'install.sh' in the 'do'  block with 'powershell.exe .\install.ps1'

