### PR TITLE
Fix install.sh shebang

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -o errexit
+
 version=$(curl -sS https://update.tabnine.com/version)
 case $(uname -s) in
     "Darwin")

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 version=$(curl -sS https://update.tabnine.com/version)
 case $(uname -s) in
     "Darwin")

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
 version=$(curl -sS https://update.tabnine.com/version)
 case $(uname -s) in
     "Darwin")


### PR DESCRIPTION
The correct portable shebang is `/usr/bin/env bash`.

The current one does not work on NixOS.