### PR TITLE
Avoid loading JSON into string before loading it (and vice versa)

### DIFF
--- a/rplugin/python3/deoplete/sources/tabnine.py
+++ b/rplugin/python3/deoplete/sources/tabnine.py
@@ -144,7 +144,7 @@ class Source(Base):
             self._restart()
             return
 
-        output = proc.stdout.readline().decode('utf8')
+        output = proc.stdout.readline()
         try:
             return json.loads(output)
         except json.JSONDecodeError:

--- a/rplugin/python3/deoplete/sources/tabnine.py
+++ b/rplugin/python3/deoplete/sources/tabnine.py
@@ -84,7 +84,6 @@ class Source(Base):
         if 'promotional_message' in response:
             self.print(' '.join(response['promotional_message']))
         candidates = []
-        #self.debug(repr(response))
         for result in response['results']:
             candidate = {'word': result['new_prefix']}
             if result['old_suffix'] or result['new_suffix']:
@@ -103,7 +102,6 @@ class Source(Base):
             if result.get('kind'):
                 candidate['kind'] = LSP_KINDS[result['kind'] - 1]
             candidates.append(candidate)
-        #self.debug(repr(candidates))
         return candidates
 
     def _get_response(self, context):

--- a/rplugin/python3/deoplete/sources/tabnine.py
+++ b/rplugin/python3/deoplete/sources/tabnine.py
@@ -165,6 +165,7 @@ class Source(Base):
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
+            encoding='utf-8',
         )
 
     def _get_running_tabnine(self):

--- a/rplugin/python3/deoplete/sources/tabnine.py
+++ b/rplugin/python3/deoplete/sources/tabnine.py
@@ -84,7 +84,7 @@ class Source(Base):
         if 'promotional_message' in response:
             self.print(' '.join(response['promotional_message']))
         candidates = []
-        self.debug(repr(response))
+        #self.debug(repr(response))
         for result in response['results']:
             candidate = {'word': result['new_prefix']}
             if result['old_suffix'] or result['new_suffix']:
@@ -103,7 +103,7 @@ class Source(Base):
             if result.get('kind'):
                 candidate['kind'] = LSP_KINDS[result['kind'] - 1]
             candidates.append(candidate)
-        self.debug(repr(candidates))
+        #self.debug(repr(candidates))
         return candidates
 
     def _get_response(self, context):
@@ -137,7 +137,8 @@ class Source(Base):
             return
 
         try:
-            proc.stdin.write((json.dumps(req) + '\n').encode('utf8'))
+            json.dump(req, proc.stdin, ensure_ascii=False, check_circular=False)
+            proc.stdin.write('\n')
             proc.stdin.flush()
         except BrokenPipeError:
             self._restart()


### PR DESCRIPTION
I'm digging into why my nvim is currently having latency between keypresses.
I don't think this was the cause,
but I did notice some potential improvements:

Main change is to stop stop creating and decoding so many strings when doing the interprocess communications.

Other change is to to comment out the debug logging,
because the call to `repr` allocates every time even when not debugging