### PR TITLE
Fix UnicodeError

### DIFF
--- a/rplugin/python3/deoplete/sources/tabnine.py
+++ b/rplugin/python3/deoplete/sources/tabnine.py
@@ -138,6 +138,8 @@ class Source(Base):
             json.dump(req, proc.stdin, ensure_ascii=False, check_circular=False)
             proc.stdin.write('\n')
             proc.stdin.flush()
+        except UnicodeError:
+            return
         except BrokenPipeError:
             self._restart()
             return

--- a/rplugin/python3/deoplete/sources/tabnine.py
+++ b/rplugin/python3/deoplete/sources/tabnine.py
@@ -135,11 +135,9 @@ class Source(Base):
             return
 
         try:
-            json.dump(req, proc.stdin, ensure_ascii=False, check_circular=False)
+            json.dump(req, proc.stdin, ensure_ascii=True, check_circular=False)
             proc.stdin.write('\n')
             proc.stdin.flush()
-        except UnicodeError:
-            return
         except BrokenPipeError:
             self._restart()
             return


### PR DESCRIPTION
I have added `UnicodeError` ignore.
Because, if the buffer contain invalid unicode data, tabnine source will be broken.