### PR TITLE
Add max_bufsize option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,22 @@ The number of lines before and after the cursor to send to TabNine. If the
 option is smaller, the performance may be improved.  (default: 1000)
 
 
+### `max_bufsize`
+
+Max buffer size to enable TabNine completion.
+(default: 100 * 1024)
+
+
 ### `max_num_results`
 
 Max results from TabNine.
 (default: 10)
 
+
 ```vim
 call deoplete#custom#var('tabnine', {
 \ 'line_limit': 500,
+\ 'max_bufsize': 200 * 1024,
 \ 'max_num_results': 20,
 \ })
 ```

--- a/rplugin/python3/deoplete/sources/tabnine.py
+++ b/rplugin/python3/deoplete/sources/tabnine.py
@@ -56,6 +56,7 @@ class Source(Base):
         self.input_pattern = r'[^\w\s]$|TabNine::\w*$'
         self.vars = {
             'line_limit': 1000,
+            'max_bufsize': 100 * 1024,
             'max_num_results': 10,
         }
 
@@ -71,6 +72,11 @@ class Source(Base):
     def get_complete_position(self, context):
         m = re.search(r'\s+$', context['input'])
         if m:
+            return -1
+
+        bufsize = self.vim.call('wordcount')['bytes']
+        if bufsize > self.get_var('max_bufsize'):
+            # Buffer is too big
             return -1
 
         self._response = self._get_response(context)


### PR DESCRIPTION
I have added `max_bufsize` option to enable TabNine completion.
Because if editing buffer is very huge, TabNine completion is very slow.

I think this option is useful.  What do you think?