### PR TITLE
Fix install.sh problem in Darwin arm64

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ do
     zip=$version/$target/TabNine.zip
     path=$version/$target/TabNine
     if [ -f binaries/$path ]; then
-        exit
+        continue
     fi
     echo Downloading version $version $target
     curl https://update.tabnine.com/bundles/$zip --create-dirs -o binaries/$zip


### PR DESCRIPTION
Fix a problem:

If os is Darwin and x86_64-apple-darwin binary is already installed, aarch64-apple-darwin binary cannot be installed.