### PR TITLE
remove unsupported command line argument

### DIFF
--- a/rplugin/python3/deoplete/sources/tabnine.py
+++ b/rplugin/python3/deoplete/sources/tabnine.py
@@ -192,7 +192,6 @@ class Source(Base):
                 path,
                 '--client', 'deoplete',
                 '--log-file-path', os.path.join(self._install_dir, 'tabnine.log'),
-                '--idle_suicide_seconds', '3600',
             ],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,


### PR DESCRIPTION
We've recently removed the support of `--idle_suicide_seconds` argument. Seems like passing it to Tabnine - crashes it. So removing it for now.